### PR TITLE
✨ fix: improve SEO titles and descriptions for items

### DIFF
--- a/src/pages/[category].astro
+++ b/src/pages/[category].astro
@@ -18,8 +18,8 @@ export async function getStaticPaths() {
 const { category } = Astro.params;
 const { categoryData } = Astro.props;
 
-const title = `${categoryData.name} Prices - Track ${categoryData.name} Prices in the USA`;
-const description = `Live tracking of ${categoryData.name.toLowerCase()} prices in the United States. Monitor costs and price trends.`;
+const title = `${categoryData.name} Prices - ${categoryData.name} Prices in the USA`;
+const description = `Price of ${categoryData.name.toLowerCase()} in the United States.`;
 ---
 
 <Layout title={title} description={description}>

--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -39,8 +39,8 @@ export async function getStaticPaths() {
 const { item } = Astro.params;
 const { itemInfo, itemData } = Astro.props;
 
-const title = `${itemInfo.name} Price - Current ${itemInfo.name} Prices and Trends in USA`;
-const description = `Track ${itemInfo.name.toLowerCase()} prices across different regions in the United States. Compare national and regional prices, view historical trends, and monitor price changes.`;
+const title = `Price of ${itemInfo.name} -  Current ${itemInfo.name} Prices and Trends in USA`;
+const description = `${itemInfo.name.toLowerCase()} prices across different regions in the United States. Compare national and regional prices, view historical trends, and monitor price changes.`;
 ---
 
 <Layout title={title} description={description}>


### PR DESCRIPTION
Update the title and description formats for item and category pages. 
Enhance clarity and SEO effectiveness by rephrasing the title to 
emphasize price tracking and simplifying the description for 
better readability.