### PR TITLE
✨ feat: add static output configuration to Astro

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,4 +9,5 @@ import sitemap from "@astrojs/sitemap";
 export default defineConfig({
   integrations: [react(), tailwind(), sitemap()],
   site: "https://priceofgoods.com",
+  output: "static",
 });


### PR DESCRIPTION
Adds the `output: "static"` configuration to the Astro 
project to ensure the site is built as a static site. 
This change improves deployment options and performance.