### PR TITLE
🔧 refactor: Update structured data for improved SEO

### DIFF
--- a/src/pages/[category].astro
+++ b/src/pages/[category].astro
@@ -20,6 +20,42 @@ const { categoryData } = Astro.props;
 const title = `${categoryData.name} Average Monthly Prices in the US`;
 const description = `average price of ${categoryData.name.toLowerCase()} with monthly updates from US Bureau of Labor Statistics data. View trends and changes over time.`;
 
+// Create Dataset structured data for the category
+const datasetStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  name: `${categoryData.name} Price Statistics Dataset`,
+  description: `Comprehensive price statistics and trends for ${categoryData.name.toLowerCase()} in the United States`,
+  url: `https://priceofgoods.com/${slugify(categoryData.name)}`,
+  keywords: [categoryData.name, "price statistics", "consumer prices", "BLS data", "price trends"],
+  creator: {
+    "@type": "Organization",
+    name: "US Bureau of Labor Statistics",
+    url: "https://www.bls.gov"
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "Price of Goods",
+    url: "https://priceofgoods.com"
+  },
+  variableMeasured: Object.values(categoryData.items).map(item => ({
+    "@type": "PropertyValue",
+    name: item.name,
+    unitText: item.unit
+  })),
+  spatialCoverage: {
+    "@type": "Country",
+    name: "United States"
+  },
+  measurementTechnique: "Statistical Survey",
+  dateModified: new Date().toISOString().split('T')[0],
+  includedInDataCatalog: {
+    "@type": "DataCatalog",
+    name: "Price of Goods Statistical Database",
+    url: "https://priceofgoods.com"
+  }
+};
+
 // Create breadcrumb structured data
 const breadcrumbData = {
   "@context": "https://schema.org",
@@ -39,63 +75,6 @@ const breadcrumbData = {
     }
   ]
 };
-
-// Create ItemList structured data for the category's products
-const itemListData = {
-  "@context": "https://schema.org",
-  "@type": "ItemList",
-  name: `${categoryData.name} Price Tracking`,
-  description: `Current prices and historical trends for ${categoryData.name.toLowerCase()} in the United States`,
-  numberOfItems: Object.keys(categoryData.items).length,
-  itemListElement: Object.entries(categoryData.items).map(([key, item], index) => ({
-    "@type": "ListItem",
-    position: index + 1,
-    item: {
-      "@type": "Product",
-      name: item.name,
-      description: `Track ${item.name.toLowerCase()} prices per ${item.unit}`,
-      url: `https://priceofgoods.com/${slugify(item.name)}`,
-      additionalProperty: [
-        {
-          "@type": "PropertyValue",
-          name: "unit",
-          value: item.unit
-        },
-        {
-          "@type": "PropertyValue",
-          name: "category",
-          value: categoryData.name
-        }
-      ]
-    }
-  }))
-};
-
-// Create Dataset structured data for the category
-const datasetData = {
-  "@context": "https://schema.org",
-  "@type": "Dataset",
-  name: `${categoryData.name} Price Statistics`,
-  description: `Historical price data for ${categoryData.name.toLowerCase()} products from the US Bureau of Labor Statistics`,
-  creator: {
-    "@type": "Organization",
-    name: "US Bureau of Labor Statistics"
-  },
-  includedInDataCatalog: {
-    "@type": "DataCatalog",
-    name: "Price of Goods"
-  },
-  distribution: {
-    "@type": "DataDownload",
-    encodingFormat: "JSON",
-    contentUrl: `https://priceofgoods.com/api/categories/${slugify(categoryData.name)}`
-  },
-  temporalCoverage: "P10Y", // Indicates 10 years of historical data
-  spatialCoverage: {
-    "@type": "Country",
-    name: "United States"
-  }
-};
 ---
 
 <Layout
@@ -108,8 +87,7 @@ const datasetData = {
 >
   <!-- Add structured data to head -->
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbData)} />
-  <script type="application/ld+json" set:html={JSON.stringify(itemListData)} />
-  <script type="application/ld+json" set:html={JSON.stringify(datasetData)} />
+  <script type="application/ld+json" set:html={JSON.stringify(datasetStructuredData)} />
 
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center">

--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -38,34 +38,44 @@ const { itemInfo, itemData } = Astro.props;
 const title = `Average Price of ${itemInfo.name} per ${itemInfo.unit}`;
 const description = `Monitor ${itemInfo.name.toLowerCase()} prices from monthly US Bureau of Labor Statistics reports. View 1-year, 4-year, and 20-year historical price trends, with official national and regional averages.`;
 
-// Create JSON-LD structured data
-const structuredData = {
+// Create JSON-LD structured data for the price dataset
+const datasetStructuredData = {
   "@context": "https://schema.org",
-  "@type": "Product",
-  name: itemInfo.name,
-  description: `Current and historical prices for ${itemInfo.name} in the United States`,
-  offers: {
-    "@type": "AggregateOffer",
-    priceCurrency: "USD",
-    price: itemData.currentPrices.national.value,
-    lowPrice: Math.min(...itemData.history.map(h => h.value)),
-    highPrice: Math.max(...itemData.history.map(h => h.value)),
-    priceValidUntil: new Date(new Date().setMonth(new Date().getMonth() + 1)).toISOString().split('T')[0],
-    availability: "https://schema.org/InStock"
+  "@type": "Dataset",
+  name: `${itemInfo.name} Price Statistics`,
+  description: `Historical and current average prices for ${itemInfo.name} in the United States, measured per ${itemInfo.unit}`,
+  keywords: [itemInfo.name, "price statistics", "consumer prices", "BLS data", "price trends"],
+  url: `https://priceofgoods.com/${slugify(itemInfo.name)}`,
+  creator: {
+    "@type": "Organization",
+    name: "US Bureau of Labor Statistics",
+    url: "https://www.bls.gov"
   },
-  additionalProperty: [
+  publisher: {
+    "@type": "Organization",
+    name: "Price of Goods",
+    url: "https://priceofgoods.com"
+  },
+  temporalCoverage: `${itemData.history[0].year}/${itemData.history[itemData.history.length - 1].year}`,
+  spatialCoverage: {
+    "@type": "Country",
+    name: "United States"
+  },
+  variableMeasured: [
     {
       "@type": "PropertyValue",
-      name: "unit",
-      value: itemInfo.unit
-    },
-    {
-      "@type": "PropertyValue",
-      name: "data_source",
-      value: "US Bureau of Labor Statistics"
+      name: "price",
+      unitText: itemInfo.unit,
+      valueReference: {
+        "@type": "PropertyValue",
+        name: "Current National Average",
+        value: itemData.currentPrices.national.value,
+        unitText: "USD"
+      }
     }
   ],
-  temporalCoverage: `${itemData.history[0].year}/${itemData.history[itemData.history.length - 1].year}`
+  measurementTechnique: "Statistical Survey",
+  dateModified: new Date().toISOString().split('T')[0]
 };
 
 // Create breadcrumb structured data
@@ -98,7 +108,7 @@ const breadcrumbData = {
     }}
 >
   <!-- Add structured data to head -->
-  <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+  <script type="application/ld+json" set:html={JSON.stringify(datasetStructuredData)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbData)} />
 
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">


### PR DESCRIPTION
Refactor JSON-LD structured data for item and category pages
to better represent the content as datasets. This change
enhances SEO by providing more accurate and detailed
information about the price statistics data. Remove redundant
structured data and consolidate into a single, comprehensive
dataset representation for each page.