### PR TITLE
🌐 refactor: Update spatialCoverage and add license

### DIFF
--- a/src/pages/[category].astro
+++ b/src/pages/[category].astro
@@ -43,10 +43,8 @@ const datasetStructuredData = {
     name: item.name,
     unitText: item.unit
   })),
-  spatialCoverage: {
-    "@type": "Country",
-    name: "United States"
-  },
+  spatialCoverage: "US",
+    license: "https://www.bls.gov/opub/opub-rights.htm",
   measurementTechnique: "Statistical Survey",
   dateModified: new Date().toISOString().split('T')[0],
   includedInDataCatalog: {

--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -57,10 +57,8 @@ const datasetStructuredData = {
     url: "https://priceofgoods.com"
   },
   temporalCoverage: `${itemData.history[0].year}/${itemData.history[itemData.history.length - 1].year}`,
-  spatialCoverage: {
-    "@type": "Country",
-    name: "United States"
-  },
+  spatialCoverage: "US",
+    license: "https://www.bls.gov/opub/opub-rights.htm",
   variableMeasured: [
     {
       "@type": "PropertyValue",


### PR DESCRIPTION
Update structured data for item and category pages:
- Simplify spatialCoverage to "US" string
- Add license field with BLS rights URL
- Remove redundant Country object structure

These changes improve data accuracy and compliance.