### PR TITLE
🔇 chore: remove console logs and adjust error logging

### DIFF
--- a/src/lib/llmcache.js
+++ b/src/lib/llmcache.js
@@ -25,7 +25,7 @@ export async function getCachedAnalysis(itemKey) {
       timestamp: cached.timestamp,
     };
   } catch (error) {
-    console.error("Error reading from cache:", error);
+    console.log("Error reading from cache:", error);
     return null;
   }
 }

--- a/src/lib/priceanalysis.js
+++ b/src/lib/priceanalysis.js
@@ -111,8 +111,8 @@ export async function analyzeItemPrices(item, useAnthropic = true) {
       throw error;
     }
     const timestamp = Date.now();
-    console.log("Returning analysis", analysis);
-    console.log("Returning citations", citations);
+    // console.log("Returning analysis", analysis);
+    // console.log("Returning citations", citations);
     // Return the analysis result with the same structure as cachedAnalysis.
     return { data: analysis, citations, timestamp };
   } catch (error) {


### PR DESCRIPTION
Remove console.log statements in priceanalysis.js and change
console.error to console.log in llmcache.js for consistency
and cleaner output. This improves code readability and
maintains a more uniform logging approach across the project.