### PR TITLE
feat: improve item page layout with responsive columns

### DIFF
--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -121,36 +121,41 @@ const breadcrumbData = {
   <!-- Add structured data to head -->
   <script type="application/ld+json" set:html={JSON.stringify(datasetStructuredData)} />
   <script type="application/ld+json" set:html={JSON.stringify(breadcrumbData)} />
-
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-    <!-- Render the item detail page component which shows the analysis markdown -->
-    <ItemDetailPage
-      item={itemInfo}
-      currentPrices={itemData.currentPrices}
-      historyData={itemData.history}
-      aiAnalysis={aiAnalysis}
-      client:load
-    />
-
-    <!-- Render the citations if there are any -->
-    {response.citations && response.citations.length > 0 && (
-      <div class="mt-8">
-        <h2 class="text-xl font-semibold mb-4">Citations</h2>
-        <ol class="list-decimal list-inside text-sm text-gray-700">
-          {response.citations.map((citation, index) => (
-            <li key={index}>
-              <a
-                href={citation}
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-blue-600 hover:underline"
-              >
-                {citation}
-              </a>
-            </li>
-          ))}
-        </ol>
+    <div class="flex flex-col md:flex-row md:gap-8">
+      <!-- Left column: Item detail page component with analysis -->
+      <div class="md:w-2/3">
+        <ItemDetailPage
+          item={itemInfo}
+          currentPrices={itemData.currentPrices}
+          historyData={itemData.history}
+          aiAnalysis={aiAnalysis}
+          client:load
+        />
       </div>
-    )}
+
+      <!-- Right column: Citations -->
+      <div class="md:w-1/3">
+        {response.citations && response.citations.length > 0 && (
+          <div class="mt-8 md:mt-0">
+            <h2 class="text-xl font-semibold mb-4">Citations</h2>
+            <ol class="list-decimal list-inside text-sm text-gray-700">
+              {response.citations.map((citation, index) => (
+                <li>
+                  <a
+                    href={citation}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-blue-600 hover:underline"
+                  >
+                    {citation}
+                  </a>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+      </div>
+    </div>
   </div>
 </Layout>

--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -141,16 +141,16 @@ const breadcrumbData = {
             <h2 class="text-xl font-semibold mb-4">Citations</h2>
             <ol class="list-decimal list-inside text-sm text-gray-700">
               {response.citations.map((citation, index) => (
-                <li>
-                  <a
-                    href={citation}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-blue-600 hover:underline"
-                  >
-                    {citation}
-                  </a>
-                </li>
+              <li key={citation}>
+                               <a
+                                 href={citation}
+                                 target="_blank"
+                                 rel="noopener noreferrer"
+                                 class="text-blue-600 hover:underline"
+                               >
+                                 {citation}
+                               </a>
+                             </li>
               ))}
             </ol>
           </div>


### PR DESCRIPTION
Restructure the item detail page with a two-column layout on medium 
and larger screens to improve readability and user experience. Move 
the main item detail component to the left column (2/3 width) and 
citations to the right column (1/3 width). 

Implement responsive behavior with single column on mobile and dual 
columns for larger screens using Tailwind's flex utilities.