### PR TITLE
feat: integrate PostHog analytics alongside Google

### DIFF
--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -1,0 +1,59 @@
+---
+
+---
+
+<script>
+  !(function (t, e) {
+    var o, n, p, r;
+    e.__SV ||
+      ((window.posthog = e),
+      (e._i = []),
+      (e.init = function (i, s, a) {
+        function g(t, e) {
+          var o = e.split(".");
+          2 == o.length && ((t = t[o[0]]), (e = o[1])),
+            (t[e] = function () {
+              t.push([e].concat(Array.prototype.slice.call(arguments, 0)));
+            });
+        }
+        ((p = t.createElement("script")).type = "text/javascript"),
+          (p.crossOrigin = "anonymous"),
+          (p.async = !0),
+          (p.src =
+            s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") +
+            "/static/array.js"),
+          (r = t.getElementsByTagName("script")[0]).parentNode.insertBefore(
+            p,
+            r
+          );
+        var u = e;
+        for (
+          void 0 !== a ? (u = e[a] = []) : (a = "posthog"),
+            u.people = u.people || [],
+            u.toString = function (t) {
+              var e = "posthog";
+              return (
+                "posthog" !== a && (e += "." + a), t || (e += " (stub)"), e
+              );
+            },
+            u.people.toString = function () {
+              return u.toString(1) + ".people (stub)";
+            },
+            o =
+              "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(
+                " "
+              ),
+            n = 0;
+          n < o.length;
+          n++
+        )
+          g(u, o[n]);
+        e._i.push([i, s, a]);
+      }),
+      (e.__SV = 1));
+  })(document, window.posthog || []);
+  posthog.init("phc_u13nPH5kg6dFpnzbCbfjwjIP4fbZNohE6rfO1OD7DJ1", {
+    api_host: "https://us.i.posthog.com",
+    person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
+  });
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,38 +3,42 @@ interface Props {
   title: string;
   description: string;
   ogImage?: {
-    type: 'categories' | 'items' | 'home';
+    type: "categories" | "items" | "home";
     slug: string;
-  }
+  };
 }
 
 const { title, description, ogImage } = Astro.props;
-const siteUrl = 'https://priceofgoods.com';
+const siteUrl = "https://priceofgoods.com";
 const fullOgImageUrl = ogImage
   ? `${siteUrl}/og-image/${ogImage.type}/${ogImage.slug}.png`
   : `${siteUrl}/default-og.png`;
 
 import "../styles/global.css";
 
-import Navigation from '../components/Navigation.astro';
-import Footer from '../components/Footer.astro';
+import Navigation from "../components/Navigation.astro";
+import Footer from "../components/Footer.astro";
+import PostHog from "../components/posthog.astro";
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NFWES7P3JD"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NFWES7P3JD"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-    gtag('config', 'G-NFWES7P3JD');
-  </script>
+      gtag("config", "G-NFWES7P3JD");
+    </script>
 
     <meta charset="UTF-8" />
-    <meta name="description" content={description}>
+    <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
@@ -52,11 +56,14 @@ import Footer from '../components/Footer.astro';
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={fullOgImageUrl} />
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="7bed8295-efd8-476a-a6e8-d35ce7f1a012"></script>
+    <script
+      defer
+      src="https://cloud.umami.is/script.js"
+      data-website-id="7bed8295-efd8-476a-a6e8-d35ce7f1a012"></script>
     <title>{title} - Price of Goods</title>
   </head>
   <body>
-
+    <PostHog />
     <nav class="bg-white shadow">
       <Navigation />
     </nav>


### PR DESCRIPTION
Add PostHog analytics to complement existing Google Analytics and 
Umami tracking. Create a new PostHog component and include it in the 
main layout for better user behavior insights. Also standardize quote 
style to double quotes and fix minor formatting issues throughout 
the layout file.