### PR TITLE
feat: update astro to v5.6.1 and ultrahtml to v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@langchain/core": "^0.3.36",
         "@radix-ui/react-separator": "^1.1.1",
         "@tailwindcss/vite": "^4.0.13",
-        "astro": "^5.6.0",
+        "astro": "^5.6.1",
         "langsmith": "^0.3.3",
         "lucide-react": "^0.469.0",
         "marked": "^15.0.6",
@@ -2915,9 +2915,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.6.0.tgz",
-      "integrity": "sha512-ZzHqdTQ4qtCnXzN9bVb75p/F0UweZYubmijjo++frn4E4KxLX8E7fizbX5Wbo2flvA6z/tUsoDwnYASxLHiM1Q==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.6.1.tgz",
+      "integrity": "sha512-aQ2TV7wIf+q2Oi6gGWMINHWEAZqoP0eH6/mihodfTJYATPWyd03JIGVfjtYUJlkNdNSKxDXwEe/r/Zx4CZ1FPg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.11.0",
@@ -2965,7 +2965,7 @@
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.12",
         "tsconfck": "^3.1.5",
-        "ultrahtml": "^1.5.3",
+        "ultrahtml": "^1.6.0",
         "unist-util-visit": "^5.0.0",
         "unstorage": "^1.15.0",
         "vfile": "^6.0.3",
@@ -7157,9 +7157,9 @@
       "license": "MIT"
     },
     "node_modules/ultrahtml": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.5.3.tgz",
-      "integrity": "sha512-GykOvZwgDWZlTQMtp5jrD4BVL+gNn2NVlVafjcFUJ7taY20tqYdwdoWBFy6GBJsNTZe1GkGPkSl5knQAjtgceg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
+      "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
       "license": "MIT"
     },
     "node_modules/uncrypto": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@langchain/core": "^0.3.36",
     "@radix-ui/react-separator": "^1.1.1",
     "@tailwindcss/vite": "^4.0.13",
-    "astro": "^5.6.0",
+    "astro": "^5.6.1",
     "langsmith": "^0.3.3",
     "lucide-react": "^0.469.0",
     "marked": "^15.0.6",


### PR DESCRIPTION
Upgrades astro package from version 5.6.0 to 5.6.1 and its 
dependency ultrahtml from 1.5.3 to 1.6.0. This update ensures we
stay current with the latest bug fixes and improvements in the Astro
framework.