### PR TITLE
feat: add repobeats analytics image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Testing Change of the README.md file
 
-"Comparing Butler Review, GitHub Reviews, and Pull Requests"
+
+![Alt](https://repobeats.axiom.co/api/embed/df56ca63d6008b0548dd0962d333b25994d73746.svg "Repobeats analytics image")
 
 This website was made so that I can easily see what the price of certain goods are, and compare them to what they were in the past.
 


### PR DESCRIPTION
Removes the comparison title and adds a repobeats analytics image 
to provide visual statistics about repository activity. This helps
users and contributors quickly understand the project's development
patterns and engagement metrics.