### PR TITLE
feat: switch price analysis to claude-sonnet model

### DIFF
--- a/src/lib/priceanalysis.js
+++ b/src/lib/priceanalysis.js
@@ -112,7 +112,7 @@ async function fetchAnalysisWithAnthropic(prompt) {
       // Call Anthropic API with web search enabled
       const response = await anthropic.messages.create(
         {
-          model: "claude-opus-4-20250514",
+          model: "claude-sonnet-4-0",
           max_tokens: 4000,
           temperature: 0.2,
           system:


### PR DESCRIPTION
Update price analysis API to use claude-sonnet-4-0 instead of 
claude-opus-4-20250514 to improve cost efficiency while maintaining
sufficient analysis quality for our current needs.

Opus 4 is EXPENSIVE! 💸