### PR TITLE
Add breadcrumb navigation component and integrate into category/item pages

### DIFF
--- a/src/components/Breadcrumb.astro
+++ b/src/components/Breadcrumb.astro
@@ -1,0 +1,79 @@
+---
+export interface BreadcrumbItem {
+  name: string;
+  href: string;
+}
+
+interface Props {
+  items: BreadcrumbItem[];
+}
+
+const { items } = Astro.props;
+---
+
+<nav aria-label="Breadcrumb" class="breadcrumb-nav">
+  <ol
+    class="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400"
+    itemscope
+    itemtype="https://schema.org/BreadcrumbList"
+  >
+    {
+      items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        return (
+          <li
+            class="flex items-center"
+            itemprop="itemListElement"
+            itemscope
+            itemtype="https://schema.org/ListItem"
+          >
+            {!isLast ? (
+              <>
+                <a
+                  href={item.href}
+                  class="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  itemprop="item"
+                >
+                  <span itemprop="name">{item.name}</span>
+                </a>
+                <meta itemprop="position" content={String(index + 1)} />
+                <svg
+                  class="w-4 h-4 mx-2 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </>
+            ) : (
+              <>
+                <span
+                  class="font-medium text-gray-900 dark:text-gray-100"
+                  itemprop="name"
+                  aria-current="page"
+                >
+                  {item.name}
+                </span>
+                <meta itemprop="position" content={String(index + 1)} />
+              </>
+            )}
+          </li>
+        );
+      })
+    }
+  </ol>
+</nav>
+
+<style>
+  .breadcrumb-nav {
+    margin-bottom: 1.5rem;
+  }
+</style>

--- a/src/pages/[category].astro
+++ b/src/pages/[category].astro
@@ -4,6 +4,7 @@ import PriceChart from '../components/react/PriceChart';
 import { fetchGoodsConfig } from '../lib/fetchUtils';
 import { slugify } from '../lib/stringUtilities';
 import CategoryRow from "../components/react/CategoryRow";
+import Breadcrumb from "../components/Breadcrumb.astro";
 // Generate all possible category routes
 export async function getStaticPaths() {
   const goodsConfig = await fetchGoodsConfig();
@@ -88,6 +89,13 @@ const breadcrumbData = {
   <script type="application/ld+json" set:html={JSON.stringify(datasetStructuredData)} />
 
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <Breadcrumb
+      items={[
+        { name: "Home", href: "/" },
+        { name: categoryData.name, href: `/${slugify(categoryData.name)}` }
+      ]}
+    />
+
     <div class="text-center">
       <h1 class="text-3xl font-bold text-gray-900 sm:text-4xl">
         {categoryData.name}

--- a/src/pages/[item].astro
+++ b/src/pages/[item].astro
@@ -8,6 +8,7 @@ import { processItemData, regions } from "../lib/dataUtils";
 import { slugify } from "../lib/stringUtilities";
 import { analyzeItemPrices } from "../lib/priceanalysis";
 import ItemDetailPage from "../components/react/ItemDetailPage";
+import Breadcrumb from "../components/Breadcrumb.astro";
 
 // Setup marked options
 marked.setOptions({
@@ -21,33 +22,30 @@ marked.setOptions({
 // Generate all possible item routes
 export async function getStaticPaths() {
     const goodsConfig = await fetchGoodsConfig();
-    const allItems = Object.values(goodsConfig.categories).reduce(
-        (items, category) => {
-            return {
-                ...items,
-                ...category.items,
-            };
-        },
-        {},
-    );
 
     const paths = await Promise.all(
-        Object.values(allItems).map(async (item) => {
-            const itemData = await processItemData(item.dataKey);
-            return {
-                params: { item: slugify(item.name) },
-                props: {
-                    itemInfo: item,
-                    itemData,
-                },
-            };
-        }),
+        Object.entries(goodsConfig.categories).flatMap(([categoryKey, category]) =>
+            Object.values(category.items).map(async (item) => {
+                const itemData = await processItemData(item.dataKey);
+                return {
+                    params: { item: slugify(item.name) },
+                    props: {
+                        itemInfo: item,
+                        itemData,
+                        categoryInfo: {
+                            name: category.name,
+                            slug: slugify(category.name)
+                        }
+                    },
+                };
+            })
+        )
     );
     return paths;
 }
 
 const { item } = Astro.params;
-const { itemInfo, itemData } = Astro.props;
+const { itemInfo, itemData, categoryInfo } = Astro.props;
 
 // Get the latest data date from history
 const latestDate =
@@ -135,6 +133,12 @@ const breadcrumbData = {
         {
             "@type": "ListItem",
             position: 2,
+            name: categoryInfo.name,
+            item: `https://priceofgoods.com/${categoryInfo.slug}`,
+        },
+        {
+            "@type": "ListItem",
+            position: 3,
             name: itemInfo.name,
             item: `https://priceofgoods.com/${slugify(itemInfo.name)}`,
         },
@@ -160,6 +164,14 @@ const breadcrumbData = {
         set:html={JSON.stringify(breadcrumbData)}
     />
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Breadcrumb
+            items={[
+                { name: "Home", href: "/" },
+                { name: categoryInfo.name, href: `/${categoryInfo.slug}` },
+                { name: itemInfo.name, href: `/${slugify(itemInfo.name)}` }
+            ]}
+        />
+
         <div class="flex flex-col md:flex-row md:gap-8">
             <!-- Left column: Item detail page component with analysis -->
             <div class="md:w-2/3">


### PR DESCRIPTION
## Changes

- Created a reusable `Breadcrumb.astro` component for breadcrumb navigation
- Added Schema.org BreadcrumbList markup for improved SEO and accessibility
- Integrated breadcrumb component into category and item pages
- Updated `getStaticPaths` for item pages to include category context
- Refactored paths generation for items
- Updated breadcrumb and structured data positioning